### PR TITLE
Copilot/redeploy on data file change

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,6 @@ on:
   workflow_run:
     workflows: ['Approve App Submission']
     types: [completed]
-    branches: [main]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,10 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [main]
+  workflow_run:
+    workflows: ['Approve App Submission']
+    types: [completed]
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -16,6 +20,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for deploying to GitHub Pages, adding support for triggering deployments after the "Approve App Submission" workflow completes, and ensuring deployments only proceed if the previous workflow was successful.

**Workflow trigger enhancements:**

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R6-R8): Added a `workflow_run` trigger so that deployments can be triggered when the "Approve App Submission" workflow completes, in addition to the existing triggers.

**Deployment condition improvements:**

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R22): Added a conditional to the `build` job to ensure it only runs if the event is not a `workflow_run` or if the previous workflow run concluded successfully, preventing deployments on failed approvals.